### PR TITLE
support multiple compilers per environment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -104,8 +104,8 @@ The packages are configured as disjoint environments, each built with the same c
 packages:
     gcc-host:
       compiler:
-          toolchain: gcc
-          spec: gcc@11.3
+          - toolchain: gcc
+            spec: gcc@11.3
       unify: true
       specs:
       - hdf5 +mpi
@@ -150,8 +150,8 @@ spack:
 packages:
     gcc-nvgpu:
       compiler:
-          toolchain: gcc
-          spec: gcc@11.3
+          - toolchain: gcc
+            spec: gcc@11.3
       unify: true
       specs:
       - cuda@11.8
@@ -181,6 +181,54 @@ spack:
   packages:
     all:
       compiler: [gcc@11.3]
+    mpi:
+      require: cray-mpich-binary
+```
+
+#### example: a nvhpc toolchain with MPI
+
+To build a toolchain with NVIDIA HPC SDK, we provide two compiler toolchains:
+- The `llvm:nvhpc` compiler;
+- A version of gcc from the `gcc` toolchain, in order to build dependencies (like CMake) that can't be built with nvhpc. If a second compiler is not provided, Spack will fall back to the system gcc 4.7.5, and not generate zen2/zen3 optimized code as a result.
+
+```yaml
+# packages.yaml
+packages:
+    prgenv-nvidia:
+      compiler:
+          - toolchain: llvm
+            spec: nvhpc
+          - toolchain: gcc
+            spec: gcc@11.3
+      unify: true
+      specs:
+      - cuda@11.8
+      - fftw%nvhpc +mpi
+      - hdf5%nvhpc +mpi
+      mpi:
+        spec: cray-mpich-binary
+        gpu: cuda
+```
+
+The following `spack.yaml` is generated:
+
+```yaml
+# spack.yaml
+spack:
+  include:
+  - compilers.yaml
+  - config.yaml
+  view: false
+  concretizer:
+    unify: True
+  specs:
+  - cuda@11.8
+  - fftw%nvhpc +mpi
+  - hdf5%nvhpc +mpi
+  - cray-mpich-binary +cuda
+  packages:
+    all:
+      compiler: [nvhpc, gcc@11.3]
     mpi:
       require: cray-mpich-binary
 ```

--- a/sstool/main.py
+++ b/sstool/main.py
@@ -310,7 +310,7 @@ class Recipe:
         makefile_template = jenv.get_template('Makefile.packages')
         push_to_cache = self.mirror.source and self.mirror.key
         files['makefile'] = makefile_template.render(
-            compilers=self.compilers, environments=self.packages,
+            environments=self.packages,
             push_to_cache=push_to_cache)
 
         files['config'] = {}
@@ -517,9 +517,7 @@ def main():
                     'the environment:\n')
         logger.info(f'cd {build.path}')
         logger.info('env --ignore-environment PATH=/usr/bin:/bin:`pwd`'
-                    '/spack/bin make modules -j32')
-        logger.info('env --ignore-environment PATH=/usr/bin:/bin:`pwd`'
-                    '/spack/bin make store.squashfs')
+                    '/spack/bin make store.squashfs -j32')
         return 0
     except Exception as e:
         logger.exception(e)

--- a/templates/Makefile.packages
+++ b/templates/Makefile.packages
@@ -25,7 +25,8 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 
 # Create the compilers.yaml configuration for each environment
 {% for env, config in environments.items() %}
-{{ env }}_PREFIX = $$($(SPACK) -e ../compilers/{{ config.compiler.toolchain }} find --format '{prefix}' {{ config.compiler.spec }})
+{{ env }}_PREFIX = {% for C in config.compiler %} $$($(SPACK) -e ../compilers/{{ C.toolchain }} find --format '{prefix}' {{ C.spec }}){% endfor %}
+
 {{ env }}/compilers.yaml:
 	$(SPACK) compiler find --scope=user $(call compiler_bin_dirs, $({{ env }}_PREFIX))
 

--- a/templates/packages.spack.yaml
+++ b/templates/packages.spack.yaml
@@ -1,3 +1,4 @@
+{% set separator = joiner(', ') %}
 spack:
   include:
   - compilers.yaml
@@ -12,7 +13,7 @@ spack:
 {% endfor %}
   packages:
     all:
-      compiler: [{{ config.compiler.spec }}]
+        compiler: [{% for c in config.compiler %}{{ separator() }}{{ c.spec }}{% endfor %}]
     {% if config.mpi.spec %}
     mpi:
       require: {{ config.mpi.spec }}

--- a/test/recipes/base-amdgpu/packages.yaml
+++ b/test/recipes/base-amdgpu/packages.yaml
@@ -1,8 +1,8 @@
 packages:
     gcc-env:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - hipsolver@5.2
@@ -19,8 +19,8 @@ packages:
         gpu: rocm
     tools:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - cmake

--- a/test/recipes/base-nvgpu/packages.yaml
+++ b/test/recipes/base-nvgpu/packages.yaml
@@ -1,8 +1,8 @@
 packages:
     gcc-env:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - cuda@11.8
@@ -12,8 +12,8 @@ packages:
         gpu: cuda
     tools:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - cmake

--- a/test/recipes/cache/packages.yaml
+++ b/test/recipes/cache/packages.yaml
@@ -1,8 +1,8 @@
 packages:
     gcc-env:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - fmt
@@ -11,8 +11,8 @@ packages:
         gpu: false
     tools:
       compiler:
-          toolchain: gcc
-          spec: gcc@11
+          - toolchain: gcc
+            spec: gcc@11
       unify: true
       specs:
       - cmake

--- a/test/recipes/host-recipe/packages.yaml
+++ b/test/recipes/host-recipe/packages.yaml
@@ -1,8 +1,8 @@
 packages:
     gcc-env:
       compiler:
-          toolchain: gcc
-          spec: gcc@11.3.0
+          - toolchain: gcc
+            spec: gcc@11.3.0
       unify: true
       specs:
       - osu-micro-benchmarks@5.9
@@ -12,8 +12,8 @@ packages:
         gpu: false
     tools:
       compiler:
-          toolchain: gcc
-          spec: gcc@11.3.0
+          - toolchain: gcc
+            spec: gcc@11.3.0
       unify: true
       specs:
       - cmake

--- a/test/recipes/unique-bootstrap/packages.yaml
+++ b/test/recipes/unique-bootstrap/packages.yaml
@@ -1,8 +1,8 @@
 packages:
     mpi:
       compiler:
-          toolchain: gcc
-          spec: gcc@12
+          - toolchain: gcc
+            spec: gcc@12
       unify: true
       specs:
       - cuda@11.8
@@ -12,8 +12,8 @@ packages:
         gpu: cuda
     tools:
       compiler:
-          toolchain: gcc
-          spec: gcc@12
+          - toolchain: gcc
+            spec: gcc@12
       unify: true
       specs:
       - cmake


### PR DESCRIPTION
Extend the `packages.yaml` recipes to accept a list of compilers instead of a single compiler.
This makes it possible to provide a fallback gcc for packages that can't be built by the primary compiler.

**Before**:
```yaml
  compiler:
    toolchain: llvm
    spec: nvhpc
```

**After**:
```yaml
  compiler:
    - toolchain: llvm
      spec: nvhpc
    - toolchain: gcc
      spec: gcc@11.3
```